### PR TITLE
don’t log Errno::ENOENT

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ Metrics/MethodLength:
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 RSpec/NestedGroups:
-  Max: 6
+  Max: 8
 RSpec/SubjectStub:
   Enabled: false
 RSpec/ExampleLength:

--- a/lib/puma_cloudwatch/metrics/looper.rb
+++ b/lib/puma_cloudwatch/metrics/looper.rb
@@ -47,7 +47,9 @@ module PumaCloudwatch
           sleep collect_frequency
           storage.aggregate(parser.call)
         rescue StandardError => e
-          puts "PumaCloudwatch Error: #{e.message} (#{e.class})"
+          # Ignore ENOENT errors, they can be raised when the Puma control app is not yet activated
+          # on startup
+          puts "PumaCloudwatch Error: #{e.message} (#{e.class})" unless e.is_a?(Errno::ENOENT)
         end
       end
 

--- a/spec/puma_cloudwatch/metrics/looper_spec.rb
+++ b/spec/puma_cloudwatch/metrics/looper_spec.rb
@@ -196,6 +196,18 @@ RSpec.describe PumaCloudwatch::Metrics::Looper do
 
               expect(looper).to have_received(:puts).with('PumaCloudwatch Error: parse error (StandardError)')
             end
+
+            context 'when the error is an ENOENT' do
+              before do
+                allow(parser).to receive(:call).and_raise(Errno::ENOENT.new('no such file or directory'))
+              end
+
+              it 'does not log the error' do
+                looper.run
+
+                expect(looper).not_to have_received(:puts)
+              end
+            end
           end
         end
 


### PR DESCRIPTION
these can be thrown on startup when the control app isn’t yet started